### PR TITLE
Add agenda 4 October and proposal page for champions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @wordshaker @jguadagno @ovebastiansen @nicoleabuhakmeh @codehippie1 @jorgelevy
+*       @wordshaker @jguadagno @ovebastiansen @nicoleabuhakmeh @codehippie1 @jorgelevy @1kevgriff

--- a/meetings/2023/10-04-meeting-minutes.md
+++ b/meetings/2023/10-04-meeting-minutes.md
@@ -1,41 +1,63 @@
-# .NET Membership Committee Meeting
+# .NET Membership Committee Meeting #
+Wednesday, 4 October 2023, 3PM EDT 
 
-### 04 October 2023 8PM GMT / 3PM ET 
-
-### Meeting Attendees
+### Meeting Attendees ###
 
 * Jessica Brentnall, *Chair*
-* 
-* Madison Hardy, *Scribe*
+* Ove Bastiansen
+* Aneesh Gopalakrishnan
+* Nicole Miller
+* Madison Hardy, Scribe
 
----
+### Attachment
+[Membership Form](https://forms.office.com/pages/responsepage.aspx?id=3G8HFsH8FUqxyjLJolWQDm8F03uiB2VCoiyUmNsltiBUQ0FDWDBFUFVURFRaQUdCUEg4MlExSEQ0OS4u)
 
-## Updates on previous meetings actions
+### Membership Applications
+* 64 member applications were received throughout September. The group split the batch for review and approvals. Jessica noted that since the application questions were updated, submissions have been easier to review, and it was a much faster approval process.
 
-### 
+### .NET Conf
+* Nicole provided a bit of context about DNF's previous involvement with .NET Conf. When Javier Lozano was on the Board, DNF was very active in the planning because Javier was involved in the programming. This year, DNF has not been asked and is not involved in the planning, but was asked to promote the conference through DNF channels. The Marketing Committee has been working on this through Mailchimp.
+* Jessica noted that the group is available to help as needed. She added that the UK MVP community has been very effectively marketing .NET Conf with swag and viewing parties.
 
----
+### DNF Champions
+* Jessica drafted a file in GitHub to track the initiative's development. The group discussed the following:
+    * Program Name
+        * Aneesh: I like the name "DNF Champions", but maybe we shorten it - DNF Champ? I also think we can make a competition out of this. Create a small survey, publish it on Discord and in the newsletter, get members engaged.
+        * Jessica: Good idea. Do want to offer a few pre-determined options so we don't end up with something silly. But this is a good way to get engagement.
+    * Program Benefits for the Foundation
+        * Jessica will draft a proposal
+    * Program Benefits for Members
+        * PDF Certificate
+            * Aneesh: Something we could do here different than MVPs would be a hand-signed certificate. Joe (or whoever is DNF President) could sign.
+        * Enamel Pin
+            * Jessica: Do we have a budget for this?
+            * Nicole: Yes, if we could get a sponsor, they could target funds for this. We can get pins pretty cheaply through [Wizard Pins](https://https://wizardpins.com/products/soft-enamel-pins?variant=14042600669239&utm_source=google&utm_medium=shopping&utm_term=Pins&utm_content=soft-enamel-pins_s3&nbt=nb%3Aadwords%3Ag%3A10022067833%3A102400061273%3A434604154450&nb_adtype=pla&nb_kwd=&nb_ti=pla-968229587997&nb_mi=125251762&nb_pc=online&nb_pi=soft-enamel-pins_s3&nb_ppi=968229587997&nb_placement=&nb_si=%7Bsourceid%7D&nb_li_ms=&nb_lp_ms=&nb_fii=&nb_ap=&nb_mt=&utm_source=google&utm_medium=paid&utm_campaign=10022067833&utm_content=102400061273&utm_term=&gadid=434604154450&nbt=nb%3Aadwords%3Ag%3A10022067833%3A102400061273%3A434604154450&nb_adtype=pla&nb_kwd=&nb_ti=pla-968229587997&nb_mi=125251762&nb_pc=online&nb_pi=soft-enamel-pins_s3&nb_ppi=968229587997&nb_placement=&nb_si=%7Bsourceid%7D&nb_li_ms=&nb_lp_ms=&nb_fii=&nb_ap=&nb_mt=&gad=1&gclid=Cj0KCQjwmvSoBhDOARIsAK6aV7hye027RXp6vo_Z551JK1DcWkK3joe6vjnjm0K0W2I6-R08Hn-a74YaAjlREALw_wcB)
+            * Aneesh: We would need a logo, something to put on the pin. Create another competition for members!
+    * Minimum Requirements
+        * Time Served on Committees
+            * Jessica: Should this be 6 months?
+            * Ove: The committee chair will need to confirm the applicant's activity in the committee.
+            * Jessica: The chairs will know, this will be straightforward to confirm.
+            * Jessica: We are building a brand - people are unsure about DNF and what we do, so we need to align on DNF's values. We want committee involvement here because active members run for the Board (which encourages this alignment between the committees and the Board).
+        * Project Involvement?
+            * Aneesh: I agree that committee participation is necessary, but we should think beyond just that. Maybe project-related?
+            * Jessica: It may be too big of an ask, requiring someone to see a project through, because we're not structured like that.
+            * Nicole: We also need to consider how to verify an approve these things.
+            * Aneesh: We also can't limit the requirements to project involvement because members of the Education Committee likely aren't working on projects.
+            * Ove: Maybe the requirement isn't that someone owns the project, but that they're contributing. We can track how many meaningful PRs, code changes, etc they've worked on.
+            * Jessica: We'll need to define "meaningful" but yes. They'll need to provide links to their projects/files if we include this requirement.
+        * Blogs / Presentations / Marketing
+            * Aneesh: People that write for DNF blogs?
+            * Jessica: Writing on your own blog doesn't carry as much weight as writing on a DNF blog, so we can account for that.
+            * Ove: Maybe speakers, people that present content at .NET events/conferences.
+    * Process for Application - TBD
+    * Review Process
+        * Ove: How many do we approve each year?
+        * Jessica: It depends on how many applications we receive, we could be flexible here.
+* The group discussed whether "DNF" was approved for marketing, with Nicole noting that it's used for the DNF Summit and there's precedent for referencing the Foundation as such. Ove suggested confirming that there won't be any legal issues by using DNF, particularly around copyrights.
+* Once the branding is determined, the group can focus on swag. 
 
-## Agenda
+### Committee Admin
+* Madison sent the poll to committee members to determine the meeting schedule moving forward. All of the respondents so far have preferred meeting on a monthly basis, and most are available to meet on the first Wednesday of each month. Madison will update the calendar invite next week.
 
-* Bring up GitHub Projects to check for any agenda items.
-
-### **Membership Form Updates**
-
-* 
-
-### **Review actions from the previous meeting**
-
-*
-
-### **DNF Champions**
-
-* 
-
-### **Any Other Business** 
-
-* 
-
----
-
-### The meeting adjourned at __:__PM ET.
+**The meeting adjourned at 3:40 PM EDT.**

--- a/meetings/2023/10-04-meeting-minutes.md
+++ b/meetings/2023/10-04-meeting-minutes.md
@@ -1,0 +1,41 @@
+# .NET Membership Committee Meeting
+
+### 04 October 2023 8PM GMT / 3PM ET 
+
+### Meeting Attendees
+
+* Jessica Brentnall, *Chair*
+* 
+* Madison Hardy, *Scribe*
+
+---
+
+## Updates on previous meetings actions
+
+### 
+
+---
+
+## Agenda
+
+* Bring up GitHub Projects to check for any agenda items.
+
+### **Membership Form Updates**
+
+* 
+
+### **Review actions from the previous meeting**
+
+*
+
+### **DNF Champions**
+
+* 
+
+### **Any Other Business** 
+
+* 
+
+---
+
+### The meeting adjourned at __:__PM ET.

--- a/resources/dnf-champions/champions-proposal.md
+++ b/resources/dnf-champions/champions-proposal.md
@@ -1,0 +1,39 @@
+# DNF Champions
+
+## Items to agree
+
+- [ ] Agree name of programme
+- [ ] Programme Benefits for .NET Foundation
+- [ ] Programme Benefits for members
+- [ ] Minimum requirements
+- [ ] Process for application
+- [ ] Review process
+- [ ] Programme Benefits 
+
+## Name of programme
+
+-
+
+## Programme Benefits for .NET Foundation
+
+- Encourages enagement in committees
+- More structured contributions
+
+## Programme Benefits for members
+
+- PDF Certificate
+
+## Minimum requirements
+
+- Time served on committee?
+
+
+## Process for application
+
+-
+
+
+## Review process
+
+-
+


### PR DESCRIPTION
## Description Of Change

- Add agenda for 4 October 2023
- Add template page to outline champions proposal for Board

![image](https://github.com/dotnet-foundation/wg-membership/assets/13496774/4b073383-b511-4a16-bc24-f82760e41195)

## Purpose Of Change

To give structure to next committee meeting

## Related Issue
